### PR TITLE
implementation of heat switch including example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+
+src/tnplot.m
+examples/switch/payload.log
+examples/switch/payload.out
+examples/switch/payload.rst
+examples/switch/payload_cond.csv
+examples/switch/payload_nd.csv
+examples/switch/payload_timedata.csv
+src/albo.pdf
+src/solar.pdf
+src/elec.pdf
+src/albedo.pdf

--- a/examples/switch/payload.inp
+++ b/examples/switch/payload.inp
@@ -1,0 +1,73 @@
+!
+! Heat switch example
+!
+! By Andrew Barton, March 11th, 2024
+!
+
+Begin Solution Parameters
+  title = Heat switch example
+  type = transient
+  begin time  = 0.0
+  end time    = 6000 
+  time step   = 100.0
+  plot functions yes 
+End Solution Parameters
+
+Begin Nodes
+  interior  2430000.0  1.000e-04  !  rho*c,  V
+  radiator  2430000.0  6.0000e-06
+  MLI_sun   21000.0    3.0000e-05    
+  MLI_rest  21000.0    3.0000e-05   
+End Nodes
+
+Begin Conductors
+! External radiation to space
+  radiator-space    surfrad    radiator  space    0.1      1.20e-01  ! emissivity, A 
+  MLI_sun-space     surfrad    MLI_sun   space    0.044    6.00e-03  ! emissivity, A   
+  MLI_rest-space    surfrad    MLI_rest  space    0.044    1.80e-02  ! emissivity, A   
+! External radiation to planet
+  MLI_sun-planet    surfrad    MLI_sun   planet   0.044    6.00e-03  ! emissivity, A  
+  MLI_rest-planet   surfrad    MLI_rest  planet   0.044    1.80e-02  ! emissivity, A 
+! MLI Conduction
+  interior-MLI_sun  conduction interior  MLI_sun  0.0006   0.005    0.0500    ! k, L, A
+  interior-MLI_rest conduction interior  MLI_rest 0.0006   0.005    0.1500    ! k, L, A
+! Conduction
+  switch_conduct    switch     interior radiator  3.00e+00 8.00e-06 25     2    ! G_on, G_off, T_switch (K), T_ramp  
+End Conductors
+
+Begin Sources
+  Qsrc    solar   MLI_sun   
+  Qsrc    albedo  MLI_sun   
+  Qsrc    albedo  MLI_rest  
+  Qsrc    elec    interior      
+End Sources
+
+Begin Boundary Conditions   
+  fixed_T -270.3  space    ! temperature of deep space in C
+  fixed_T -3      planet   ! earth
+End Boundary Conditions
+
+Begin Functions
+  Begin Time Table solar  !  function for solar flux vs time
+     0       3
+     3000    3
+     3000    0            
+     6000    0
+  End Time Table solar
+  Begin Time Table albedo  !  function for albedo flux vs time
+     0       0.5
+     3000    0.5
+     3000    0
+     6000    0
+  End Time Table albedo
+  Begin Time Table elec  !  function for electronics heat dissipation vs time
+     0       6
+     1500    6
+     1500    0.1
+     6000    0.1
+  End Time Table elec
+End Functions
+
+Begin Initial Conditions  
+   20    all     !  Ti, node   
+End Initial Conditions

--- a/src/elmat_switch.m
+++ b/src/elmat_switch.m
@@ -1,0 +1,21 @@
+function [lhs, rhs] = elmat_switch(el, Tel, rhs)
+%
+% Created by ACB on 3/3/2024
+%
+
+% determine Gswitch, the conductance (kL/A) of the switch based on the temperature of node 1
+if Tel(1) > el.Tswitch + el.Tramp/2
+ Gswitch=el.Uon;
+elseif Tel(1) < el.Tswitch - el.Tramp/2
+ Gswitch=el.Uoff;
+else
+ slope=(el.Uon-el.Uoff)/el.Tramp;
+ offset=Tel(1)-el.Tswitch;
+ Gav=(el.Uon-el.Uoff)/2;
+ Gswitch=Gav + offset * slope;
+end
+
+ lhs = Gswitch*[  1.0, -1.0 ;   ...
+                    -1.0,  1.0 ];
+
+ rhs = rhs - lhs*Tel;  %  Element residual

--- a/src/elpost_switch.m
+++ b/src/elpost_switch.m
@@ -1,0 +1,21 @@
+function [el, Q] = elpost_switch(el, Tel)
+%
+% Created by ACB on 3/3/2024
+%
+
+% determine Gswitch, the conductance (kL/A) of the switch based on the temperature of node 1
+if Tel(1) > el.Tswitch + el.Tramp/2
+ Gswitch=el.Uon;
+elseif Tel(1) < el.Tswitch - el.Tramp/2
+ Gswitch=el.Uoff;
+else
+ slope=(el.Uon-el.Uoff)/el.Tramp;
+ offset=Tel(1)-el.Tswitch;
+ Gav=(el.Uon-el.Uoff)/2;
+ Gswitch=Gav + offset * slope;
+end
+
+
+Q = Gswitch*(Tel(1)-Tel(2));
+el.Q = Q;
+el.U = NaN;    %   No area is defined for switches, just their conductance. NB. In readinp.m I set el.A as NaN

--- a/src/elpre_switch.m
+++ b/src/elpre_switch.m
@@ -1,0 +1,6 @@
+function [el] = elpre_switch(el, mat, Tel)
+%
+% Created by ACB on 3/3/2024
+%
+
+% This function is empty since the switch type conductor doesn't need to preset any values.

--- a/src/writeout.m
+++ b/src/writeout.m
@@ -13,6 +13,13 @@ function writeout(fid, spar, nd, el, bc, src, ic, enc, mat)
 %
 %    Model written to requested file.
 %
+%  History:
+%
+%    Who    Date   Version  Note
+%    ---  -------- -------  -----------------------------------------------
+%    RJC  ???
+%    ACB  03/03/24  0.1.0   Added (unused) case 24, for switch, in Conductor Parameters output to the .out file
+%
 %==========================================================================
 
 u = setunits(spar.units);
@@ -81,7 +88,7 @@ if nsrc > 0
       fprintf(fid,' %s', char(src(i).nds(j)));
     end
     fprintf(fid,'\n');
-  end  
+  end
 end
 
 %--------------------------------------------------------------------------
@@ -103,7 +110,7 @@ if nbc > 0
       fprintf(fid,' %s', char(bc(i).nds(j)));
     end
     fprintf(fid,'\n');
-  end  
+  end
 end
 
 %--------------------------------------------------------------------------
@@ -121,7 +128,7 @@ if nic > 0
       fprintf(fid,' %s', char(nd(ic(i).nd(j)).label));
     end
     fprintf(fid,'\n');
-  end  
+  end
 end
 
 %--------------------------------------------------------------------------
@@ -159,13 +166,14 @@ fprintf(fid,'\n*** Conductor Parameters ***\n');
 
 for e=1:nel
   types(e) = el(e).elst;
-end  
+end
 types = unique(types);
 
 for i=1:length(types)
   switch types(i)
 
     case 1  %  Conduction
+    case 24 %  Switch
     case 2  %  Convection
     case 3  %  Radiation
       fprintf(fid,'\nradiation: Surface to Surface Radiation\n\n');
@@ -349,7 +357,7 @@ for i=1:length(types)
         end
       end
   end
-end  
+end
 
 %--------------------------------------------------------------------------
 %  Output the CV energy balance for each node
@@ -398,7 +406,7 @@ for n=1:nnd
       else
         dir = 'in';
       end
-    end     
+    end
     fprintf(fid,'%10s - %10s - %10s, %10g %10g %10g    %s\n', el(e).nd1, el(e).label, el(e).nd2, ...
       nd(el(e).elnd(1)).T, nd(el(e).elnd(2)).T, el(e).Q,dir);
   end


### PR DESCRIPTION
The heat switch is implemented as a new type of conductor element.
The example is for a satellite payload in earth orbit. In this example, the switch exhibits three behaviours:
1) initially it engages fully once the interior temperature of the payload climbs to 25C
2) once the internal power dissipation is reduced, the heat switch only has intermittant engagement as the temperature periodically rises above 25C
3) after the satellite enters eclipse the external heating from solar radiation and albedo drops and the payload stays below 25C, resulting in the switch remaining off for the rest of the simulation